### PR TITLE
Reset connection state when connectGatt() throws SecurityException

### DIFF
--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/state/ConnectionState.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/state/ConnectionState.kt
@@ -30,7 +30,8 @@ sealed class ConnectionState {
             LINK_LOSS,
             NOT_SUPPORTED,
             CANCELLED,
-            TIMEOUT;
+            TIMEOUT,
+            PERMISSION_DENIED;
 
             companion object {
                 internal fun parse(reason: Int): Reason = when (reason) {
@@ -41,6 +42,7 @@ sealed class ConnectionState {
                     ConnectionObserver.REASON_NOT_SUPPORTED -> NOT_SUPPORTED
                     ConnectionObserver.REASON_CANCELLED -> CANCELLED
                     ConnectionObserver.REASON_TIMEOUT -> TIMEOUT
+                    ConnectionObserver.REASON_PERMISSION_DENIED -> PERMISSION_DENIED
                     else -> UNKNOWN
                 }
             }
@@ -57,6 +59,10 @@ sealed class ConnectionState {
         /** Whether the connection timed out. */
         val isTimeout: Boolean
             get() = reason == Reason.TIMEOUT
+
+        /** Whether a permission required to use Bluetooth is missing. */
+        val isPermissionDenied: Boolean
+            get() = reason == Reason.PERMISSION_DENIED
     }
 
     /**

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -759,33 +759,54 @@ abstract class BleManagerHandler extends RequestHandler {
 		}
 		connectionTime = SystemClock.elapsedRealtime();
 		earlyPhyLe2MRequest = false;
-		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
-			// connectRequest will never be null here.
-			final int preferredPhy = connectRequest.getPreferredPhy();
-			log(Log.DEBUG, () ->
-					"gatt = device.connectGatt(autoConnect = " + autoConnect + ", TRANSPORT_LE, "
-							+ ParserUtils.phyMaskToString(preferredPhy) + ")");
+		try {
+			if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+				// connectRequest will never be null here.
+				final int preferredPhy = connectRequest.getPreferredPhy();
+				log(Log.DEBUG, () ->
+						"gatt = device.connectGatt(autoConnect = " + autoConnect + ", TRANSPORT_LE, "
+								+ ParserUtils.phyMaskToString(preferredPhy) + ")");
 
-			bluetoothGatt = device.connectGatt(context, autoConnect, gattCallback,
-					BluetoothDevice.TRANSPORT_LE, preferredPhy, handler);
-		} else if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O) {
-			// connectRequest will never be null here.
-			final int preferredPhy = connectRequest.getPreferredPhy();
-			log(Log.DEBUG, () ->
-					"gatt = device.connectGatt(autoConnect = " + autoConnect + ", TRANSPORT_LE, "
-							+ ParserUtils.phyMaskToString(preferredPhy) + ")");
-			// A variant of connectGatt with Handled can't be used here.
-			// Check https://github.com/NordicSemiconductor/Android-BLE-Library/issues/54
-			// This bug specifically occurs in SDK 26 and is fixed in SDK 27
-			bluetoothGatt = device.connectGatt(context, autoConnect, gattCallback,
-					BluetoothDevice.TRANSPORT_LE, preferredPhy/*, handler*/);
-		} else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-			log(Log.DEBUG, () -> "gatt = device.connectGatt(autoConnect = " + autoConnect + ", TRANSPORT_LE)");
-			bluetoothGatt = device.connectGatt(context, autoConnect, gattCallback,
-					BluetoothDevice.TRANSPORT_LE);
-		} else {
-			log(Log.DEBUG, () -> "gatt = device.connectGatt(autoConnect = " + autoConnect + ")");
-			bluetoothGatt = device.connectGatt(context, autoConnect, gattCallback);
+				bluetoothGatt = device.connectGatt(context, autoConnect, gattCallback,
+						BluetoothDevice.TRANSPORT_LE, preferredPhy, handler);
+			} else if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O) {
+				// connectRequest will never be null here.
+				final int preferredPhy = connectRequest.getPreferredPhy();
+				log(Log.DEBUG, () ->
+						"gatt = device.connectGatt(autoConnect = " + autoConnect + ", TRANSPORT_LE, "
+								+ ParserUtils.phyMaskToString(preferredPhy) + ")");
+				// A variant of connectGatt with Handled can't be used here.
+				// Check https://github.com/NordicSemiconductor/Android-BLE-Library/issues/54
+				// This bug specifically occurs in SDK 26 and is fixed in SDK 27
+				bluetoothGatt = device.connectGatt(context, autoConnect, gattCallback,
+						BluetoothDevice.TRANSPORT_LE, preferredPhy/*, handler*/);
+			} else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+				log(Log.DEBUG, () -> "gatt = device.connectGatt(autoConnect = " + autoConnect + ", TRANSPORT_LE)");
+				bluetoothGatt = device.connectGatt(context, autoConnect, gattCallback,
+						BluetoothDevice.TRANSPORT_LE);
+			} else {
+				log(Log.DEBUG, () -> "gatt = device.connectGatt(autoConnect = " + autoConnect + ")");
+				bluetoothGatt = device.connectGatt(context, autoConnect, gattCallback);
+			}
+		} catch (final SecurityException e) {
+			// device.connectGatt(...) throws a SecurityException when the BLUETOOTH_CONNECT
+			// permission has been revoked, for example in the system settings. As the connection
+			// state was set to CONNECTING above, it has to be rolled back here, otherwise the
+			// manager would be stuck in that state and the request queue would stay blocked.
+			log(Log.ERROR, e::getLocalizedMessage);
+			connectionState = BluetoothGatt.STATE_DISCONNECTED;
+			connectionTime = 0L;
+			initialConnection = false;
+			bluetoothDevice = null;
+			final ConnectRequest cr = this.connectRequest;
+			this.connectRequest = null;
+			if (cr != null) {
+				cr.notifyFail(device, FailCallback.REASON_REQUEST_FAILED);
+			}
+			postConnectionStateChange(o -> o.onDeviceFailedToConnect(device,
+					ConnectionObserver.REASON_PERMISSION_DENIED));
+			nextRequest(true);
+			throw e;
 		}
 
 		if (autoConnect && this.connectRequest != null) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/annotation/DisconnectionReason.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/annotation/DisconnectionReason.java
@@ -39,5 +39,6 @@ import no.nordicsemi.android.ble.observer.ConnectionObserver;
 		ConnectionObserver.REASON_NOT_SUPPORTED,
 		ConnectionObserver.REASON_CANCELLED,
 		ConnectionObserver.REASON_TIMEOUT,
+		ConnectionObserver.REASON_PERMISSION_DENIED,
 })
 public @interface DisconnectionReason {}

--- a/ble/src/main/java/no/nordicsemi/android/ble/observer/ConnectionObserver.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/observer/ConnectionObserver.java
@@ -69,6 +69,19 @@ public interface ConnectionObserver {
 	 * but this seems to fix the problem only before a new bond is created.
 	 */
 	int REASON_UNSUPPORTED_CONFIGURATION = 11;
+	/**
+	 * The connection could not be established, or was terminated, because the app is missing
+	 * a permission required to use Bluetooth, that is {@link android.Manifest.permission#BLUETOOTH_CONNECT}
+	 * on Android 12 (API 31) and newer.
+	 * <p>
+	 * This is reported when a call to the Android Bluetooth API threw a {@link SecurityException},
+	 * which happens when the permission was never granted, or was revoked by the user in the
+	 * system settings. Note, that revoking a permission kills the app process, so this is most
+	 * likely to be seen when the app connects automatically after being restarted.
+	 * <p>
+	 * Request the missing permission and try connecting again.
+	 */
+	int REASON_PERMISSION_DENIED = 12;
 
 	/**
 	 * Called when the Android device started connecting to given device.

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         applicationId "no.nordicsemi.andorid.ble.test"
-        minSdk 21
+        minSdk 23
         targetSdk 36
         versionCode 1
         versionName "1.0"
@@ -48,6 +48,11 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    testOptions {
+        unitTests {
+            returnDefaultValues = true
+        }
+    }
 }
 
 dependencies {
@@ -78,4 +83,7 @@ dependencies {
 
     // Test
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.16.1'
+    testImplementation 'androidx.test:core:1.7.0'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
 }

--- a/test/src/test/java/no/nordicsemi/andorid/ble/test/regression/RevokedConnectPermissionTest.kt
+++ b/test/src/test/java/no/nordicsemi/andorid/ble/test/regression/RevokedConnectPermissionTest.kt
@@ -1,0 +1,189 @@
+package no.nordicsemi.andorid.ble.test.regression
+
+import android.Manifest
+import android.app.Application
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import no.nordicsemi.android.ble.BleManager
+import no.nordicsemi.android.ble.ktx.suspend
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * Reproduces the state corruption that happens when `BluetoothDevice.connectGatt(...)` throws a
+ * [SecurityException] because the `BLUETOOTH_CONNECT` runtime permission has been revoked.
+ *
+ * Real world scenario:
+ *
+ *  1. The user revokes the "Nearby devices" permission in the OS settings. Android kills the
+ *     process.
+ *  2. The process is restarted and the (singleton) BleManager tries to connect straight away.
+ *  3. [no.nordicsemi.android.ble.BleManagerHandler] `internalConnect()` sets
+ *     `connectionState = STATE_CONNECTING` and *then* calls `device.connectGatt(...)`, which
+ *     throws a SecurityException. `Request.enqueue()` runs `nextRequest()` synchronously on the
+ *     caller's thread, so the exception escapes out of `connect(device).suspend()` and nothing
+ *     ever rolls the state back.
+ *  4. The user grants the permission again. The singleton looks at `getConnectionState()`, sees
+ *     STATE_CONNECTING and concludes a connection attempt is already in flight, so it never
+ *     retries. And even when it does retry, `operationInProgress` is still `true`, so the new
+ *     ConnectRequest is only queued and never executed.
+ *
+ * The three tests below assert the behavior we *want*. They all currently fail - that is the bug.
+ */
+@RunWith(RobolectricTestRunner::class)
+// SDK 31+ is required: that is where BLUETOOTH_CONNECT started being enforced.
+@Config(sdk = [34], application = Application::class)
+class RevokedConnectPermissionTest {
+
+    private lateinit var context: Application
+    private lateinit var device: BluetoothDevice
+    private lateinit var manager: TestBleManager
+
+    /** The bare minimum BleManager, standing in for the app's singleton manager. */
+    private class TestBleManager(context: Context) : BleManager(context) {
+        override fun getMinLogPriority(): Int = Int.MAX_VALUE // silence the logs
+        override fun log(priority: Int, message: String) = Unit
+        override fun isRequiredServiceSupported(gatt: BluetoothGatt): Boolean = true
+        override fun initialize() = Unit
+        override fun onServicesInvalidated() = Unit
+    }
+
+    @Before
+    @Suppress("DEPRECATION") // BluetoothAdapter.getDefaultAdapter()
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        // The permission is revoked, exactly as it is after the user turned it off in Settings
+        // and the process was restarted.
+        context.denyBluetoothConnect()
+
+        val adapter = BluetoothAdapter.getDefaultAdapter()
+        shadowOf(adapter).setEnabled(true)
+        device = adapter.getRemoteDevice(DEVICE_ADDRESS)
+        // Makes connectGatt(...) throw a SecurityException while BLUETOOTH_CONNECT is not granted,
+        // which is what the framework does on a real device.
+        shadowOf(device).setShouldThrowSecurityExceptions(true)
+
+        manager = TestBleManager(context)
+    }
+
+    /**
+     * After `connect().suspend()` blows up with a SecurityException, the manager must be back in
+     * a usable, disconnected state.
+     *
+     * Currently fails: `connectionState` is left at `STATE_CONNECTING` (1).
+     */
+    @Test
+    fun connectionStateIsResetWhenConnectGattThrowsSecurityException() {
+        assertEquals(BluetoothGatt.STATE_DISCONNECTED, manager.connectionState)
+
+        connectExpectingSecurityException()
+
+        // Drain anything the manager posted to the main looper before inspecting the state.
+        ShadowLooper.shadowMainLooper().idle()
+
+        assertFalse("Manager reports itself as connected", manager.isConnected)
+        assertEquals(
+            "connectionState was not rolled back after connectGatt() threw",
+            BluetoothGatt.STATE_DISCONNECTED,
+            manager.connectionState,
+        )
+    }
+
+    /**
+     * The plain (non-coroutine) API must not leave the request queue blocked either.
+     *
+     * `Request.enqueue()` runs `nextRequest()` on the calling thread, so the SecurityException is
+     * thrown straight at the caller, after `operationInProgress` has already been set to `true`
+     * and before any callback could be notified. Nothing resets it, so every request enqueued
+     * afterwards is only added to the queue and never executed.
+     *
+     * Note: `ConnectRequest.suspend()` accidentally recovers from this, because the coroutine is
+     * cancelled and `TimeoutableRequest.cancel()` -> `cancelCurrent()` -> `nextRequest(force)`
+     * clears the flag. The stale `connectionState` survives even that.
+     */
+    @Test
+    fun requestQueueIsNotBlockedWhenConnectGattThrows() {
+        try {
+            manager.connect(device).enqueue()
+            fail("Expected connectGatt(...) to throw a SecurityException")
+        } catch (expected: SecurityException) {
+            // Expected.
+        }
+        ShadowLooper.shadowMainLooper().idle()
+
+        // The user goes back to Settings and grants the permission again.
+        context.grantBluetoothConnect()
+
+        manager.connect(device).enqueue()
+        ShadowLooper.shadowMainLooper().idle()
+
+        assertEquals(
+            "The second ConnectRequest never reached connectGatt() - the queue is wedged",
+            1,
+            shadowOf(device).bluetoothGatts.size,
+        )
+    }
+
+    /**
+     * The scenario as the app actually experiences it: a singleton manager that only starts a
+     * connection when it believes it is disconnected.
+     *
+     * Currently fails: after the permission is granted back the manager still reports
+     * `STATE_CONNECTING`, so the app never retries and stays offline until the process is killed.
+     */
+    @Test
+    fun singletonRetriesConnectingAfterThePermissionIsGrantedBack() {
+        connectExpectingSecurityException()
+        ShadowLooper.shadowMainLooper().idle()
+
+        // The user goes back to Settings and grants the permission again.
+        context.grantBluetoothConnect()
+
+        // This guard is what a typical singleton manager does when the app comes to foreground.
+        // Enqueued rather than suspended, because nothing simulates the GATT callbacks here and
+        // the request would never complete.
+        if (manager.connectionState == BluetoothGatt.STATE_DISCONNECTED) {
+            manager.connect(device).enqueue()
+        }
+        ShadowLooper.shadowMainLooper().idle()
+
+        assertEquals(
+            "The manager still reports STATE_CONNECTING, so the app never retried",
+            1,
+            shadowOf(device).bluetoothGatts.size,
+        )
+    }
+
+    private fun connectExpectingSecurityException() {
+        try {
+            runBlocking { manager.connect(device).suspend() }
+            fail("Expected connectGatt(...) to throw a SecurityException")
+        } catch (expected: SecurityException) {
+            // This is what the app sees on a real device after the permission was revoked.
+        }
+        // Nothing was created, the connection attempt never started.
+        assertEquals(0, shadowOf(device).bluetoothGatts.size)
+    }
+
+    private fun Application.denyBluetoothConnect() =
+        shadowOf(this).denyPermissions(Manifest.permission.BLUETOOTH_CONNECT)
+
+    private fun Application.grantBluetoothConnect() =
+        shadowOf(this).grantPermissions(Manifest.permission.BLUETOOTH_CONNECT)
+
+    private companion object {
+        const val DEVICE_ADDRESS = "AA:BB:CC:DD:EE:FF"
+    }
+}

--- a/test/src/test/java/no/nordicsemi/andorid/ble/test/regression/RevokedConnectPermissionTest.kt
+++ b/test/src/test/java/no/nordicsemi/andorid/ble/test/regression/RevokedConnectPermissionTest.kt
@@ -10,6 +10,7 @@ import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking
 import no.nordicsemi.android.ble.BleManager
 import no.nordicsemi.android.ble.ktx.suspend
+import no.nordicsemi.android.ble.observer.ConnectionObserver
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.fail
@@ -118,7 +119,7 @@ class RevokedConnectPermissionTest {
         try {
             manager.connect(device).enqueue()
             fail("Expected connectGatt(...) to throw a SecurityException")
-        } catch (expected: SecurityException) {
+        } catch (_: SecurityException) {
             // Expected.
         }
         ShadowLooper.shadowMainLooper().idle()
@@ -166,11 +167,38 @@ class RevokedConnectPermissionTest {
         )
     }
 
+    /**
+     * The failure must be reported to the [ConnectionObserver] with a reason that tells the app
+     * what actually went wrong, so it can re-request the permission instead of guessing.
+     */
+    @Test
+    fun observerIsNotifiedWithPermissionDeniedReason() {
+        var failedDevice: BluetoothDevice? = null
+        var failureReason: Int? = null
+        manager.setConnectionObserver(object : ConnectionObserver {
+            override fun onDeviceConnecting(device: BluetoothDevice) = Unit
+            override fun onDeviceConnected(device: BluetoothDevice) = Unit
+            override fun onDeviceReady(device: BluetoothDevice) = Unit
+            override fun onDeviceDisconnecting(device: BluetoothDevice) = Unit
+            override fun onDeviceDisconnected(device: BluetoothDevice, reason: Int) = Unit
+            override fun onDeviceFailedToConnect(device: BluetoothDevice, reason: Int) {
+                failedDevice = device
+                failureReason = reason
+            }
+        })
+
+        connectExpectingSecurityException()
+        ShadowLooper.shadowMainLooper().idle()
+
+        assertEquals(device, failedDevice)
+        assertEquals(ConnectionObserver.REASON_PERMISSION_DENIED, failureReason)
+    }
+
     private fun connectExpectingSecurityException() {
         try {
             runBlocking { manager.connect(device).suspend() }
             fail("Expected connectGatt(...) to throw a SecurityException")
-        } catch (expected: SecurityException) {
+        } catch (_: SecurityException) {
             // This is what the app sees on a real device after the permission was revoked.
         }
         // Nothing was created, the connection attempt never started.


### PR DESCRIPTION
Fixes #655.

`internalConnect()` sets `connectionState = STATE_CONNECTING` right before calling
`connectGatt(...)`, which is unguarded. If `BLUETOOTH_CONNECT` was revoked, that throws a
`SecurityException` and nothing cleans up — the manager is stuck at `STATE_CONNECTING` with a
blocked queue forever, even after the permission comes back. It's the only `internal*` method in
that class that doesn't catch `SecurityException`.

- Wrapped the four `connectGatt(...)` branches in `try` / `catch (SecurityException)`: roll back the
  state, fail the pending request, call `nextRequest(true)`, rethrow. Most of the diff is
  reindentation.
- Added `ConnectionObserver.REASON_PERMISSION_DENIED` — nothing existing fit. Also wired into
  `@DisconnectionReason` and the ktx `Reason` enum.
- Tests are Robolectric, no hardware needed. All four fail before the fix.

Two side notes: the `minSdk 21 → 23` commit is just to make the `test` app build at all
(`hilt-navigation-compose` needs 23) — happy to split it out.